### PR TITLE
Relicense to Apache-2.0 and add funding links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: [blanpa]
+buy_me_a_coffee: blanpa

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -50,7 +50,7 @@ A Node-RED user can wire any OPC UA interaction — Client/Server (today) and Pu
 - **OPC UA PubSub Security Key Service (SKS) server implementation** — clients can use externally-managed keys; building an SKS server is a separate milestone
 - **PubSub configuration via OPC UA address space** (Part 14 §6.2.7) — initial release uses Node-RED-driven static config only; runtime reconfiguration via UA model is a future enhancement
 - **Reverse PubSub / discovery announcements** — explicitly deferred; static endpoint configuration is sufficient for v1
-- **Adopting the commercial node-opcua PubSub package** — would change the suite's licensing posture (currently MIT). All PubSub code is implemented in-tree.
+- **Adopting the commercial node-opcua PubSub package** — would change the suite's licensing posture (currently Apache-2.0). All PubSub code is implemented in-tree.
 - **Replacing or refactoring existing Client/Server nodes** — PubSub is purely additive; no breaking changes to the eight existing nodes
 - **WebSocket / HTTP transports for PubSub** — Part 14 lists them as "future"; not pursuing in this milestone
 
@@ -75,7 +75,7 @@ A Node-RED user can wire any OPC UA interaction — Client/Server (today) and Pu
 
 ## Constraints
 
-- **License**: MIT — all PubSub code must be MIT-compatible; no GPL/AGPL deps, no commercial node-opcua PubSub bindings
+- **License**: Apache-2.0 — all PubSub code must be Apache-2.0-compatible; no GPL/AGPL deps, no commercial node-opcua PubSub bindings
 - **Tech stack**: Node.js ≥18, Node-RED ≥3.0, CommonJS, no TypeScript, no transpiler — all PubSub code is plain JS
 - **Direct runtime deps**: minimize additions. New deps OK for transports (`mqtt`, `amqplib` or equivalent) but UADP encoding stays in-tree
 - **Compatibility**: zero breaking changes to existing eight nodes; PubSub adds new nodes/types only
@@ -88,7 +88,7 @@ A Node-RED user can wire any OPC UA interaction — Client/Server (today) and Pu
 
 | Decision | Rationale | Outcome |
 |----------|-----------|---------|
-| Implement PubSub UADP encoding in-tree (not via commercial node-opcua) | Preserves MIT licensing; avoids vendor lock; full control over Part 14 conformance | — Pending (locked into Active scope) |
+| Implement PubSub UADP encoding in-tree (not via commercial node-opcua) | Preserves Apache-2.0 licensing; avoids vendor lock; full control over Part 14 conformance | — Pending (locked into Active scope) |
 | Both Publisher and Subscriber roles in v1 | Node-RED users routinely need both directions; symmetric design avoids second milestone | — Pending |
 | All three transports in v1 (UDP-UADP + MQTT + AMQP) | Per-user request; covers full Part 14 spec scope. May be split if SPEC ambiguity surfaces | — Pending — re-evaluate during /gsd-spec-phase |
 | New PubSub config node(s) — do not extend `opcua-endpoint` | PubSub is session-less; ref-counted TCP socket model doesn't apply; transports differ | — Pending |

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -118,7 +118,7 @@ Explicitly excluded. Documented to prevent scope creep.
 | PubSub configuration via UA address space (Part 14 §9) | Requires embedding the full PubSub Information Model in `opcua-server`. Static Node-RED config is the v1/v2 mechanism. |
 | Discovery announcements / reverse PubSub | Adds protocol state machine complexity disproportionate to v1/v2 benefit. Static PublisherId+topic config is sufficient. |
 | WebSocket / HTTP transport | Not standardised in current Part 14. No conformant interoperability target. Use MQTT with broker-level WebSocket bridging instead. |
-| Commercial node-opcua PubSub bindings (`@sterfive/...`) | Changes the suite's MIT licensing posture; vendor lock-in. UADP is implemented in-tree. |
+| Commercial node-opcua PubSub bindings (`@sterfive/...`) | Changes the suite's Apache-2.0 licensing posture; vendor lock-in. UADP is implemented in-tree. |
 | Per-field QoS or priority routing | Part 14 only defines Priority at WriterGroup level. Per-field QoS would be non-conformant. Use multiple WriterGroups. |
 | Replacing or refactoring existing eight Client/Server nodes | PROJECT.md constraint: zero breaking changes. Any shared-utility improvements must be backwards-compatible. |
 | `amqplib` for AMQP transport | Implements AMQP 0-9-1; Part 14 §B.3 normatively requires AMQP 1.0 (use `rhea` instead). |

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -79,7 +79,7 @@ node-red-contrib-opcua-suite/
 ├── docker-entrypoint-dev.sh
 ├── docker-start.sh
 ├── Makefile
-├── LICENSE                             # MIT
+├── LICENSE                             # Apache-2.0
 ├── .dockerignore
 ├── .gitignore
 ├── .npmignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,12 @@
   (section 4b). It remains fully permissive: commercial use, closed-source
   derivatives and forks are all still allowed.
 - **`NOTICE` added** and verified to ship inside the npm tarball.
-- **Fork guidance in the README.** Forks published under a different package
-  name are asked to rename their Node-RED node type IDs and use their own
-  palette category, so both packages can be installed side by side.
+- **Contributing and fork guidance in the README.** Pull requests are welcome,
+  including large ones — an issue up front means substantial work can usually
+  land here instead of in a parallel package. Forks that are published under
+  their own package name are asked to rename their Node-RED node type IDs and
+  use their own palette category, so both packages can be installed side by
+  side.
 
 ## 0.1.7 (2026-07-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+## 0.1.8 (2026-08-26)
+
+### Changed
+
+- **License changed from MIT to Apache-2.0.** Apache-2.0 is the license
+  Node-RED itself uses. Compared to MIT it adds an explicit patent grant
+  (section 3), keeps attribution intact downstream through the new `NOTICE`
+  file (section 4d), and requires modified files to be marked as changed
+  (section 4b). It remains fully permissive: commercial use, closed-source
+  derivatives and forks are all still allowed.
+- **`NOTICE` added** and verified to ship inside the npm tarball.
+- **Fork guidance in the README.** Forks published under a different package
+  name are asked to rename their Node-RED node type IDs and use their own
+  palette category, so both packages can be installed side by side.
+
 ## 0.1.7 (2026-07-20)
 
 ### Fixed

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,201 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2026 blanpa
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 blanpa
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,9 @@
+node-red-contrib-opcua-suite
+Copyright 2026 blanpa
+
+This product includes software developed by blanpa and the
+node-red-contrib-opcua-suite contributors
+(https://github.com/blanpa/node-red-contrib-opcua-suite).
+
+Portions contributed by:
+  Dennis Bleul

--- a/README.md
+++ b/README.md
@@ -485,11 +485,16 @@ Apache License 2.0 — see [LICENSE](LICENSE) and [NOTICE](NOTICE).
 
 Copyright 2026 blanpa
 
-## Forks
+## Contributing and forks
 
-Forks are welcome. If you publish a fork under a different package name, please
-also rename the Node-RED node type IDs (for example `myprefix-opcua-suite-*`) and
-use your own palette category. Node-RED refuses to register a node type that is
-already claimed, so identical type IDs make it impossible to install both
-packages side by side.
+Pull requests are welcome, including large ones. If you are planning a bigger
+change — a dependency migration, a restructure, new nodes — please open an issue
+first. We are happy to discuss it and to land substantial work here; that is
+usually less effort than maintaining a parallel package, and it keeps a single
+place for users to report bugs.
+
+If you do publish a fork under its own package name, please also rename the
+Node-RED node type IDs (for example `myprefix-opcua-suite-*`) and use your own palette
+category. Node-RED refuses to register a node type that is already claimed, so
+identical type IDs make it impossible to install both packages side by side.
 

--- a/README.md
+++ b/README.md
@@ -481,8 +481,15 @@ falls through to the primary so the retry/reconnect path above kicks in.
 
 ## License
 
-MIT
+Apache License 2.0 — see [LICENSE](LICENSE) and [NOTICE](NOTICE).
 
-## Author
+Copyright 2026 blanpa
 
-blanpa
+## Forks
+
+Forks are welcome. If you publish a fork under a different package name, please
+also rename the Node-RED node type IDs (for example `myprefix-opcua-suite-*`) and
+use your own palette category. Node-RED refuses to register a node type that is
+already claimed, so identical type IDs make it impossible to install both
+packages side by side.
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # node-red-contrib-opcua-suite
 
+[![GitHub Sponsors](https://img.shields.io/badge/Sponsor-GitHub-EA4AAA?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/blanpa)
+[![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-FFDD00?logo=buymeacoffee&logoColor=black)](https://buymeacoffee.com/blanpa)
+
 An OPC UA suite for Node-RED.
 
 ## Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-opcua-suite",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "A modern OPC UA suite for Node-RED — Client/Server plus OPC UA PubSub (UDP-UADP / MQTT) with shared connections, batch operations, drag-and-drop certificates, and a clean msg-driven API",
   "keywords": [
     "node-red",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "format": "prettier --write nodes/**/*.js lib/**/*.js"
   },
   "author": "blanpa",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "dependencies": {
     "mqtt": "^5.15.1",
     "node-opcua": "^2.115.0"


### PR DESCRIPTION
Relicenses the package from MIT to Apache-2.0 and finishes the surrounding cleanup.

## Why Apache-2.0
Same license Node-RED itself uses. Compared to MIT it adds an explicit patent grant and a trademark clause, without adding copyleft obligations.

## Changes
- docs: add funding links and finish Apache-2.0 relicense
- docs: invite pull requests alongside the fork guidance
- release: prepare v0.1.8 (Apache-2.0)
- chore: relicense from MIT to Apache-2.0

## Details
- `LICENSE` replaced with the full Apache-2.0 text, copyright holder filled in
- `NOTICE` added
- `package.json` → `"license": "Apache-2.0"`
- Remaining MIT references in badges and docs updated
- Release prep for `v0.1.8`
- `.github/FUNDING.yml` + sponsor badges (GitHub Sponsors, Buy Me a Coffee)

Third-party MIT attributions (dependencies, bundled upstream components) were left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)