### PR TITLE
Use real sponsor buttons and a live sponsor badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # node-red-contrib-opcua-suite
 
-[![GitHub Sponsors](https://img.shields.io/badge/Sponsor-GitHub-EA4AAA?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/blanpa)
-[![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-FFDD00?logo=buymeacoffee&logoColor=black)](https://buymeacoffee.com/blanpa)
+[![Sponsor](https://img.shields.io/github/sponsors/blanpa?label=Sponsor&logo=githubsponsors&logoColor=white&color=EA4AAA)](https://github.com/sponsors/blanpa)
 
 An OPC UA suite for Node-RED.
 
@@ -481,6 +480,18 @@ falls through to the primary so the retry/reconnect path above kicks in.
 - **`readMultiple` is the throughput win.** One batch call returns ~7× the values
   of a single read at similar latency — prefer it (or subscriptions) over many
   single `read` ops in hot flows.
+
+## Sponsor this project
+
+This package is developed and maintained in my own time.
+If it saves you some, consider supporting it:
+
+<a href="https://github.com/sponsors/blanpa">
+  <img height="41" alt="Sponsor on GitHub" src="https://img.shields.io/badge/Sponsor%20on%20GitHub-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white">
+</a>
+<a href="https://buymeacoffee.com/blanpa">
+  <img height="41" alt="Buy Me a Coffee" src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png">
+</a>
 
 ## License
 


### PR DESCRIPTION
Follow-up to the Apache-2.0 relicense PR.

## Changes
- Badge row: the two static funding badges are replaced by a single **Sponsor** badge showing the live sponsor count (`img.shields.io/github/sponsors/blanpa`).
- New **Sponsor this project** section above the license, with the official Buy Me a Coffee button (`cdn.buymeacoffee.com/buttons/v2/default-yellow.png`) and a matching 41px GitHub Sponsors button.

## Note
GitHub's own sponsor button (`github.com/sponsors/<user>/button`) is an `<iframe>` and is stripped by GitHub's README sanitizer, so it cannot be embedded here. The repo header already shows the native ❤️ Sponsor button via `.github/FUNDING.yml`.

The section is named "Sponsor this project" rather than "Support" because several READMEs already have a "Support" section for issue reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)